### PR TITLE
remove title from tray

### DIFF
--- a/src/utils/environment/systray.ts
+++ b/src/utils/environment/systray.ts
@@ -56,7 +56,6 @@ export const createSystray = () => {
         tray.setContextMenu(contextMenu);
       };
 
-      tray.setTitle('Soundsync');
       refreshMenu();
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
* just a minor tweak, but the system tray icon is pretty huge on my Mac (Mojave)
* the icon itself is already pretty big, so I hope there's no need for the title?

![Screenshot 2020-10-11 at 09 16 23](https://user-images.githubusercontent.com/524274/95672608-74f8c500-0ba2-11eb-901d-49bae177ac57.png)

