### PR TITLE
Upgrade node and sentry/webpack-plugin to fix building for multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is used only for the rendezvous service
 
-FROM node:12 AS builder
+FROM node:14 AS builder
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ COPY ./rendezvous-service/tsconfig.json ./rendezvous-service/
 COPY ./rendezvous-service/src ./rendezvous-service/src/
 RUN cd rendezvous-service && yarn build
 
-FROM node:12-alpine AS runner
+FROM node:14-alpine AS runner
 
 EXPOSE 8080
 ENV NODE_ENV=production

--- a/webui/package.json
+++ b/webui/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .jsx,.js --fix src"
   },
   "devDependencies": {
-    "@sentry/webpack-plugin": "^1.13.0",
+    "@sentry/webpack-plugin": "^1.18.9",
     "@types/chromecast-caf-receiver": "^5.0.5",
     "clean-webpack-plugin": "^3.0.0",
     "compression-webpack-plugin": "^6.0.3",


### PR DESCRIPTION
I'm trying to get this running in a Docker container so that I can deploy it as a hass.io addon.

I'm not sure if this Dockerfile was really intended for this purpose, but I found a few issues where it wouldn't build with node 12 and the version of `sentry/cli` (dendency of `sentry/webpack-plugin`) couldn't install the binary for `aarch64`.

I didn't rebuild the lock files, so that probably needs to get updated as well though.